### PR TITLE
chore: update release workflow by updating npm and adjusting node setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,16 +17,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
         with:
-            node-version: 20.x
-            registry-url: 'https://registry.npmjs.org'
+          node-version: 20.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - run: pnpm install
       
@@ -39,10 +38,8 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           if [[ "$TAG" =~ -(next|canary|beta|rc) ]]; then
-            # Extract pre-release tag (e.g., beta, rc)
             NPM_TAG=${BASH_REMATCH[1]}
           else
-            # Check if the commit is on the main branch
             git fetch origin main
             if git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
               NPM_TAG="latest"
@@ -56,6 +53,4 @@ jobs:
           echo "Using npm tag: $NPM_TAG"
 
       - name: Publish to npm
-        run: pnpm publish --access public --provenance --no-git-checks --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are confined to the GitHub Actions release workflow; main risk is a release/publish failure if npm/pnpm assumptions differ in CI.
> 
> **Overview**
> Modernizes the release GitHub Actions workflow by consolidating Node setup (including npm registry config) and adding a step to update npm to the latest version before installing dependencies.
> 
> Switches the publish step from `pnpm publish` (with `--no-git-checks`/token env) to `npm publish` while preserving provenance and the computed npm dist-tag gating (pre-release tags vs `latest` only from `main`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24b9bbff39d00077c5ad9f02f51e0f6ecb7062c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->